### PR TITLE
Remove unavailable framework import within WatchOS

### DIFF
--- a/Sources/DisplayLink/DisplayLink.swift
+++ b/Sources/DisplayLink/DisplayLink.swift
@@ -1,5 +1,4 @@
 import Foundation
-import QuartzCore
 import Combine
 
 


### PR DESCRIPTION
This is already imported where it is required (iOS / tvOS)

[DisplayLink.swift:L107](https://github.com/timdonnelly/DisplayLink/blob/master/Sources/DisplayLink/DisplayLink.swift#L107)
